### PR TITLE
FIX: max-width not working correctly

### DIFF
--- a/scss/mixins/_responsive.scss
+++ b/scss/mixins/_responsive.scss
@@ -23,19 +23,19 @@ $wrapper-max:         66.625em !default; // ~1200px [1]
 $breakpoints: (
   xs: (
     min:        0,
-    max:        (34.375em - 0.0625em), // 549px
+    max:        (34.375em - 0.02px), // 549px
   ),
   sm: (
     min:        34.375em, // 550px
-    max:        (48em - 0.0625em), // 767px
+    max:        (48em - 0.02px), // 767px
   ),
   md: (
     min:        48em, // 768px
-    max:        (58.75em - 0.0625em), // 939px
+    max:        (58.75em - 0.02px), // 939px
   ),
   lg: (
     min:        58.75em, // 940px
-    max:        (68.75em - 0.0625em), // 1099px
+    max:        (68.75em - 0.02px), // 1099px
   ),
   xl: (
     min:        68.75em, // 1100px
@@ -47,7 +47,7 @@ $breakpoints: (
 $additional_breakpoints: (
   menu: (
     min:        48em, // 768px
-    max:        (48em - 0.0625em), // 767px
+    max:        (48em - 0.02px), // 767px
   )
 ) !default;
 


### PR DESCRIPTION
**Problem:** 
rounding bug under windows, 
0.0625em was not equal 1px, so i could happen, that min-width and max-width would be the same

**Solution:** 
reduce max-width viewport by 0,02 Pixel, see [bootstrap solution](https://github.com/twbs/bootstrap/blob/v5.0.0/scss/mixins/_breakpoints.scss#L34-L47) 