### PR TITLE
Fix typo in _variables.scss

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -56,7 +56,7 @@ html {
   // --------------------------------------------------
 
   // BASE/LAYOUT
-  --layout-spacing-sides:      var(--base-spacing-unit;)
+  --layout-spacing-sides:      var(--base-spacing-unit);
   --layout-wrapper-background: transparent;
   --layout-header-background:  var(--color-page-background);
   --layout-header-color:       var(--color-text);


### PR DESCRIPTION
Variable was not declared due to twisted characters